### PR TITLE
Fix compilation error and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.4.1"
+          otp-version: "27"
+          gleam-version: "1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/src/fiber/backend.gleam
+++ b/src/fiber/backend.gleam
@@ -14,10 +14,10 @@ import gleam/string
 import fiber/message
 import fiber/response
 
-type RequestCallback =
+pub type RequestCallback =
   fn(Option(Dynamic)) -> Result(Json, response.Error)
 
-type NotificationCallback =
+pub type NotificationCallback =
   fn(Option(Dynamic)) -> Nil
 
 type RequestReplySubject =


### PR DESCRIPTION
You missed to mark two types as `pub` in the last commit when splitting files into directories. Also update the OTP version in the GH Actions workflow file to v27, which is required for the used `gleam_json` package version.